### PR TITLE
issue/41

### DIFF
--- a/repository/BaselineOfCargo.package/BaselineOfCargo.class/instance/babyMock..st
+++ b/repository/BaselineOfCargo.package/BaselineOfCargo.class/instance/babyMock..st
@@ -1,0 +1,8 @@
+baseline
+babyMock: spec
+	spec
+		project: 'BabyMock2'
+		with: [ spec
+				className: #ConfigurationOfBabyMock2;
+				versionString: #stable;
+				repository: 'http://smalltalkhub.com/mc/zeroflag/BabyMock2/main/' ]

--- a/repository/BaselineOfCargo.package/BaselineOfCargo.class/instance/baseline..st
+++ b/repository/BaselineOfCargo.package/BaselineOfCargo.class/instance/baseline..st
@@ -1,76 +1,47 @@
 baseline
 baseline: spec
 	<baseline>
-	spec for: #common do: [ 
-		spec 
-			project: 'BabyMock2' with: [
-				spec
-					className: #ConfigurationOfBabyMock2;
-					versionString: #'stable';
-					repository: 'http://smalltalkhub.com/mc/zeroflag/BabyMock2/main/' ];
-			project: 'DependencyAnalyser' with: [
-				spec
-					className: #ConfigurationOfDependencyAnalyser;
-					versionString: #'development';
-					repository: 'http://smalltalkhub.com/mc/PharoExtras/Tool-DependencyAnalyser/main/' ];
-			project: 'MooseAlgos' with: [
-				spec
-					className: #ConfigurationOfMooseAlgos;
-					versionString: #'bleedingEdge';
-					loads: #('Moose-Algos-Graph' );
-					repository: 'http://smalltalkhub.com/mc/Moose/MooseAlgos/main/' ];
-			" STON is already in the image, do not overwrite this version
-			 project: 'Ston' with: [
-				spec
-					className: #ConfigurationOfSton;
-					versionString: #'stable';
-					repository: 'http://smalltalkhub.com/mc/SvenVanCaekenberghe/STON/main/' ];"
-			baseline: 'Voyage' with: [
-				spec
-					repository: 'github://pharo-nosql/voyage:master/mc';
-					loads: #('memory' 'mongo tests') ];
-			" Iceberg is already in the image, do not overwrite this version 
-			baseline: 'Iceberg' with: [
-				spec
-					repository: 'github://pharo-vcs/iceberg:dev-0.4' ];"
-			project: 'ZincHTTPComponents' with: [
-				spec
-					className: #ConfigurationOfZincHTTPComponents;
-					versionString: #'bleedingEdge';
-					loads: #('REST');
-					repository: 'http://smalltalkhub.com/mc/SvenVanCaekenberghe/ZincHTTPComponents/main/' ];
-			project: 'Calypso' with: [ "Cargo has a project plugin for Calypso browser"
-				spec
-					className: #ConfigurationOfCalypso;
-					versionString: #stable;
-					repository: 'http://smalltalkhub.com/mc/Pharo/Calypso/main/' ].
-		spec 
-			package: #CargoPackageManager with: [
-				spec requires: #(#'CargoPackageManager-Minimal' 'ZincHTTPComponents' 'MooseAlgos' "'Iceberg'"). ];
-			package: #'CargoPackageManager-Minimal' "with: [
-				spec requires: #('Ston' ). ]";
-			package: #'CargoPackageManager-Repository' with: [
-				spec requires: #(#CargoPackageManager #'CargoPackageManager-RepositoryBackend' #'CargoPackageManager-TestRessources' 'ZincHTTPComponents' ). ];
-			package: #'CargoPackageManager-RepositoryBackend' with: [
-				spec requires: #(#CargoPackageManager #'CargoPackageManager-TestRessources' 'Voyage' ). ];
-			package: #'CargoPackageManager-Spec';
-			package: #'CargoPackageManager-TestRessources' with: [
-				spec requires: #(#CargoPackageManager #'CargoPackageManager-Spec' 'BabyMock2' ). ];
-			package: #'CargoPackageManager-Tests' with: [
-				spec requires: #(#CargoPackageManager #'CargoPackageManager-RepositoryBackend' #'CargoPackageManager-TestRessources' "'Ston'" ). ];
-			package: #'CargoPackageManager-Tests-FooResource';
-			package: #'CargoPackageManager-UI' with: [
-				spec requires: #(#CargoPackageManager ). ];
-			package: #'CargoPackageManager-Calypso-Environment' with: [
-				spec requires: #(#CargoPackageManager #Calypso). ];
-			package: #'CargoPackageManager-Calypso-Browser' with: [
-				spec requires: #(#CargoPackageManager #Calypso #'CargoPackageManager-UI' #'CargoPackageManager-Calypso-Environment'). ];
-			package: 'CargoPackageManager-Utils' with: [
-				spec requires: #('DependencyAnalyser' ). ];
-			package: #'CargoPackageManager-Utils-Tests' with: [
-				spec requires: #(#'CargoPackageManager-Tests-FooResource' ). ].
-		spec 
-			group: 'client' with: #(#CargoPackageManager #'CargoPackageManager-Calypso-Browser');
-			group: 'server' with: #(#'CargoPackageManager-RepositoryBackend' #'CargoPackageManager-Repository' );
-			group: 'tests' with: #('CargoPackageManager-Tests' 'utils' #'CargoPackageManager-Utils-Tests' );
-			group: 'utils' with: #('CargoPackageManager-Utils' 'client' ). ]
+	spec
+		for: #common
+		do: [ 
+			self babyMock: spec.
+			self mooseAlgos: spec.
+			self voyage: spec.
+			self zincHttpComponents: spec.
+			
+			spec
+				package: #'CargoPackageManager-Minimal';
+				package: #CargoPackageManager
+					with: [ spec requires: #('CargoPackageManager-Minimal' 'ZincHTTPComponents' 'MooseAlgos') ];
+
+				package: #'CargoPackageManager-Repository'
+					with: [ spec requires: #(CargoPackageManager 'CargoPackageManager-RepositoryBackend' 'CargoPackageManager-TestRessources' 'ZincHTTPComponents') ];
+				package: #'CargoPackageManager-RepositoryBackend'
+					with: [ spec requires: #(CargoPackageManager 'CargoPackageManager-TestRessources' 'Voyage') ];
+				package: #'CargoPackageManager-Spec';
+				package: #'CargoPackageManager-TestRessources'
+					with: [ spec requires: #(CargoPackageManager 'CargoPackageManager-Spec' 'BabyMock2') ];
+				package: #'CargoPackageManager-Tests'
+					with: [ spec requires: #(CargoPackageManager 'CargoPackageManager-RepositoryBackend' 'CargoPackageManager-TestRessources') ];
+				package: #'CargoPackageManager-Tests-FooResource';
+				package: #'CargoPackageManager-UI'
+					with: [ spec requires: #(CargoPackageManager) ];
+				package: #'CargoPackageManager-Calypso-Environment'
+					with: [ spec requires: #(CargoPackageManager) ];
+				package: #'CargoPackageManager-Calypso-Browser'
+					with: [ spec requires: #(CargoPackageManager 'CargoPackageManager-UI' 'CargoPackageManager-Calypso-Environment') ];
+				package: 'CargoPackageManager-Utils';
+				package: #'CargoPackageManager-Utils-Tests'
+					with: [ spec requires: #('CargoPackageManager-Tests-FooResource') ].	
+
+			spec
+				group: 'client'
+					with: #(CargoPackageManager 'CargoPackageManager-Calypso-Browser');
+				group: 'server'
+					with:
+					#(#'CargoPackageManager-RepositoryBackend' 'CargoPackageManager-Repository');
+				group: 'tests'
+					with:
+					#('CargoPackageManager-Tests' 'utils' 'CargoPackageManager-Utils-Tests');
+				group: 'utils' with: #('CargoPackageManager-Utils' 'client');
+				group: 'development' with: #(client server tests utils) ]

--- a/repository/BaselineOfCargo.package/BaselineOfCargo.class/instance/mooseAlgos..st
+++ b/repository/BaselineOfCargo.package/BaselineOfCargo.class/instance/mooseAlgos..st
@@ -1,0 +1,9 @@
+baseline
+mooseAlgos: spec
+	spec
+		project: 'MooseAlgos'
+		with: [ spec
+				className: #ConfigurationOfMooseAlgos;
+				versionString: #bleedingEdge;
+				loads: #('Moose-Algos-Graph');
+				repository: 'http://smalltalkhub.com/mc/Moose/MooseAlgos/main/' ]

--- a/repository/BaselineOfCargo.package/BaselineOfCargo.class/instance/voyage..st
+++ b/repository/BaselineOfCargo.package/BaselineOfCargo.class/instance/voyage..st
@@ -1,0 +1,7 @@
+baseline
+voyage: spec
+	spec
+		baseline: 'Voyage'
+		with: [ spec
+				repository: 'github://pharo-nosql/voyage:master/mc';
+				loads: #('memory' 'mongo tests') ]

--- a/repository/BaselineOfCargo.package/BaselineOfCargo.class/instance/zincHttpComponents..st
+++ b/repository/BaselineOfCargo.package/BaselineOfCargo.class/instance/zincHttpComponents..st
@@ -1,0 +1,10 @@
+baseline
+zincHttpComponents: spec
+	spec
+		project: 'ZincHTTPComponents'
+		with: [ spec
+				className: #ConfigurationOfZincHTTPComponents;
+				versionString: #bleedingEdge;
+				loads: #('REST');
+				repository:
+					'http://smalltalkhub.com/mc/SvenVanCaekenberghe/ZincHTTPComponents/main/' ]


### PR DESCRIPTION
Fix #41
Cleaning up the baseline of Cargo, removing the dependencies to projects already in the image, and organizing the baseline in methods.