### PR TITLE
issue/141

### DIFF
--- a/repository/CargoPackageManager-Minimal/CGODependencyConstraint.class.st
+++ b/repository/CargoPackageManager-Minimal/CGODependencyConstraint.class.st
@@ -14,11 +14,12 @@ Class {
 { #category : #'instance creation' }
 CGODependencyConstraint class >> fromString: aString [
 	| constraintString |
-	
+	"It only supports fixed versions"
 	constraintString := aString trim.
 	(constraintString first = $=)
-		ifTrue: [ ^ CGOFixedVersionConstraint with: (SemanticVersion fromString: constraintString allButFirst ) ]
-		ifFalse: [ CGODependencyConstraintFormatError signal ]
+		ifTrue: [ constraintString := constraintString allButFirst ].
+		
+	^ CGOFixedVersionConstraint with: (SemanticVersion fromString: constraintString )
 ]
 
 { #category : #testing }

--- a/repository/CargoPackageManager-Minimal/CGOFixedVersionConstraint.class.st
+++ b/repository/CargoPackageManager-Minimal/CGOFixedVersionConstraint.class.st
@@ -60,7 +60,7 @@ CGOFixedVersionConstraint >> mergeFixedVersionConstraint: aFixedVersionConstrain
 
 { #category : #printing }
 CGOFixedVersionConstraint >> printOn: aStream [
-	aStream nextPut: $=.
+
 	aStream nextPutAll: version printString 
 ]
 

--- a/repository/CargoPackageManager-Minimal/InvalidSemanticVersion.class.st
+++ b/repository/CargoPackageManager-Minimal/InvalidSemanticVersion.class.st
@@ -1,0 +1,55 @@
+Class {
+	#name : #InvalidSemanticVersion,
+	#superclass : #Object,
+	#instVars : [
+		'version'
+	],
+	#category : #'CargoPackageManager-Minimal-Model-Versions'
+}
+
+{ #category : #'instance creation' }
+InvalidSemanticVersion class >> fromString: aString [
+	^ self new 
+		version: aString;
+		yourself
+]
+
+{ #category : #comparing }
+InvalidSemanticVersion >> = anotherVersion [
+	
+	self == anotherVersion ifTrue: [ ^ true ].
+	self species ~= anotherVersion species ifTrue: [ ^ false ].
+	^ self version = anotherVersion version
+]
+
+{ #category : #converting }
+InvalidSemanticVersion >> asSemanticVersion [
+	^ self
+]
+
+{ #category : #comparing }
+InvalidSemanticVersion >> hash [
+
+	^ version hash
+]
+
+{ #category : #testing }
+InvalidSemanticVersion >> isInvalid [
+	^ true
+]
+
+{ #category : #printing }
+InvalidSemanticVersion >> printOn: aStream [
+	
+	aStream nextPutAll: version asString
+]
+
+{ #category : #accessing }
+InvalidSemanticVersion >> version [
+	^ version
+]
+
+{ #category : #accessing }
+InvalidSemanticVersion >> version: anObject [
+	version := anObject
+]

--- a/repository/CargoPackageManager-Minimal/PBMetacelloProject.class.st
+++ b/repository/CargoPackageManager-Minimal/PBMetacelloProject.class.st
@@ -55,14 +55,10 @@ PBMetacelloProject >> = anotherProject [
 
 { #category : #converting }
 PBMetacelloProject >> asPackageVersionReference [
-	| semanticVersion |
-	semanticVersion := [ SemanticVersion fromString: version ]
-		on: SemanticVersionFormatError
-		do: [ SemanticVersion fromString: '0.0.0-' , version printString ].
 
 	^ CGOPackageVersionReference 
 		packageName: self packageName 
-		version: semanticVersion
+		version: (SemanticVersion fromString: version)
 ]
 
 { #category : #'compatibility - CGOProject' }

--- a/repository/CargoPackageManager-Minimal/SemanticVersion.class.st
+++ b/repository/CargoPackageManager-Minimal/SemanticVersion.class.st
@@ -24,7 +24,7 @@ Class {
 		'patch',
 		'suffix'
 	],
-	#category : 'CargoPackageManager-Minimal-Model'
+	#category : #'CargoPackageManager-Minimal-Model-Versions'
 }
 
 { #category : #'instance creation' }
@@ -36,12 +36,12 @@ SemanticVersion class >> fromString: aString [
 	
 	version := self new.
 	parts := $. split: aString.
-	(parts size > 3) ifTrue: [ SemanticVersionFormatError signal: aString ].
+	(parts size > 3) ifTrue: [ ^ InvalidSemanticVersion fromString: aString ].
 	
 	majorNumber := (parts at: 1) asInteger.
-	majorNumber ifNil: [ SemanticVersionFormatError signal: 'Wrong major format' ].
+	majorNumber ifNil: [ ^ InvalidSemanticVersion fromString: aString ].
 	[ minorNumber := (parts at: 2) asInteger.
-	minorNumber ifNil: [ SemanticVersionFormatError signal: 'Wrong minor format' ].
+	minorNumber ifNil: [ ^ InvalidSemanticVersion fromString: aString ].
 	patchNumber := (parts at: 3) asInteger. ]
 		on: SubscriptOutOfBounds
 		do: [ "if minor and/or patch version is not specified, keep nil" ].
@@ -124,6 +124,11 @@ SemanticVersion >> isDevelopmentVersion [
 	^ suffix 
 		ifNil: [ false ]
 		ifNotNil: [ suffix endsWith: '-dev' ]
+]
+
+{ #category : #testing }
+SemanticVersion >> isInvalid [
+	^ false
 ]
 
 { #category : #accessing }

--- a/repository/CargoPackageManager-Minimal/SemanticVersionFormatError.class.st
+++ b/repository/CargoPackageManager-Minimal/SemanticVersionFormatError.class.st
@@ -1,8 +1,0 @@
-"
-Error raised when the symbolic version format is not respected.
-"
-Class {
-	#name : #SemanticVersionFormatError,
-	#superclass : #Error,
-	#category : 'CargoPackageManager-Minimal-Model'
-}

--- a/repository/CargoPackageManager-Tests/CGODependencyConstraintTest.class.st
+++ b/repository/CargoPackageManager-Tests/CGODependencyConstraintTest.class.st
@@ -18,21 +18,13 @@ CGODependencyConstraintTest >> testFromString [
 		equals: CGOFixedVersionConstraint.
 	self
 		assert: dependency asString
-		equals: '=1.0.0'
-]
-
-{ #category : #tests }
-CGODependencyConstraintTest >> testFromStringWithBadValue [
-	self
-		should: [ CGODependencyConstraint fromString: 'foo' ]
-		raise: CGODependencyConstraintFormatError
+		equals: '1.0.0'
 ]
 
 { #category : #tests }
 CGODependencyConstraintTest >> testFromStringWithBadVersion [
-	self
-		should: [ CGODependencyConstraint fromString: '=foo' ]
-		raise: SemanticVersionFormatError
+
+	self assert: (CGODependencyConstraint fromString: '=foo') version isInvalid
 ]
 
 { #category : #tests }

--- a/repository/CargoPackageManager-Tests/CGOPackageDependencyTest.class.st
+++ b/repository/CargoPackageManager-Tests/CGOPackageDependencyTest.class.st
@@ -108,19 +108,14 @@ CGOPackageDependencyTest >> testCreateDependencyWithNoConstraintsShouldCreateNoC
 ]
 
 { #category : #'tests-creation' }
-CGOPackageDependencyTest >> testCreateDependencyWithWrongConstraintShouldFail [
-	self
-		should: [ CGOPackageDependency newFrom: #A -> #('foo') ]
-		raise: CGODependencyConstraintFormatError
-	
-]
+CGOPackageDependencyTest >> testCreateDependencyWithoutEqualGeneratesAConstraint [
+	| dep |
 
-{ #category : #'tests-creation' }
-CGOPackageDependencyTest >> testCreateDependencyWithWrongVersionNumberShouldFail [
-	self
-		should: [ CGOPackageDependency newFrom: #A -> #('=foo') ]
-		raise: SemanticVersionFormatError
-	
+	dep := CGOPackageDependency newFrom: #A -> #('1.1.1').
+
+	self assert: dep constraints size equals: 1.
+	self assert: dep constraints anyOne class equals: CGOFixedVersionConstraint.
+	self deny: dep constraints anyOne version isInvalid.
 ]
 
 { #category : #'tests-serialization' }
@@ -136,7 +131,7 @@ CGOPackageDependencyTest >> testDependencyLiteralRepresentationShouldBeDependenc
 	| dependency |
 	dependency := CGOPackageDependency newFrom: #A -> #('=1.0.0').
 
-	self assert: dependency asLiteral equals: #A -> #('=1.0.0')
+	self assert: dependency asLiteral equals: #A -> #('1.0.0')
 ]
 
 { #category : #'tests-version comparison' }

--- a/repository/CargoPackageManager-Tests/CGOSemanticVersionTest.class.st
+++ b/repository/CargoPackageManager-Tests/CGOSemanticVersionTest.class.st
@@ -79,7 +79,7 @@ CGOSemanticVersionTest >> testVersionShouldBeGreaterThanVersionWithSmallerMajorN
 { #category : #'tests-parsing' }
 CGOSemanticVersionTest >> testVersionStringInvalidShouldFail [
 
-	self should: [ SemanticVersion fromString: 'toto' ] raise: SemanticVersionFormatError
+	self assert: (SemanticVersion fromString: 'toto') isInvalid
 ]
 
 { #category : #'tests-parsing' }
@@ -97,7 +97,7 @@ CGOSemanticVersionTest >> testVersionStringWithMinorNumberShouldOnlyHaveMajorAnd
 { #category : #'tests-parsing' }
 CGOSemanticVersionTest >> testVersionStringWithMoreThanThreeComponentsShouldFail [
 
-	self should:  [ SemanticVersion fromString: '1.2.3.4' ] raise: SemanticVersionFormatError
+	self assert: (SemanticVersion fromString: '1.2.3.4') isInvalid
 ]
 
 { #category : #'tests-parsing' }

--- a/repository/CargoPackageManager-Tests/CGOVcsSerializedPackageUnitV1Test.class.st
+++ b/repository/CargoPackageManager-Tests/CGOVcsSerializedPackageUnitV1Test.class.st
@@ -41,7 +41,7 @@ CGOVcsSerializedPackageUnitV1Test >> testCanDeserializeDepedencyThatIsAnAssociat
 		equals: 1.
 	self 
 		assert: dependency constraints first asString
-		equals: '=1.1.0'.
+		equals: '1.1.0'.
 ]
 
 { #category : #tests }

--- a/repository/CargoPackageManager-Tests/PharoLauncherProject.class.st
+++ b/repository/CargoPackageManager-Tests/PharoLauncherProject.class.st
@@ -30,27 +30,27 @@ PharoLauncherProject >> buildAndRegisterIn: aCGOPackageRegistry [
 
 { #category : #building }
 PharoLauncherProject >> buildExternalProjectDependencies [
-	project addExternalCargoProject: 
+	project addDependency:
 		(PBMetacelloConfigurationProjectDependency
 			name: 'JSON' 
 			repositoryUrl: 'http://smalltalkhub.com/mc/PharoExtras/JSON/main/'
 			version: #stable).
-	project addExternalCargoProject: 
+	project addDependency: 
 		(PBMetacelloConfigurationProjectDependency 
 			name: 'Ston'
 			repositoryUrl: 'http://ss3.gemstone.com/ss/STON'
 			version: #stable).
-	project addExternalCargoProject: 
+	project addDependency: 
 		(PBMetacelloConfigurationProjectDependency 
 			name: 'OSProcess'
 			repositoryUrl: 'http://www.squeaksource.com/MetacelloRepository'
 			version: #stable).
-	project addExternalCargoProject: 
+	project addDependency: 
 		(PBMetacelloConfigurationProjectDependency 
 			name: 'ProcessWrapper'
 			repositoryUrl: 'http://smalltalkhub.com/mc/hernan/ProcessWrapper/main/'
 			version: #bleedingEdge).
-	project addExternalCargoProject: 
+	project addDependency: 
 		(PBMetacelloConfigurationProjectDependency 
 			name: 'XMLParser'
 			repositoryUrl: 'hhttp://smalltalkhub.com/mc/PharoExtras/XMLParser/main/'
@@ -59,23 +59,23 @@ PharoLauncherProject >> buildExternalProjectDependencies [
 
 { #category : #building }
 PharoLauncherProject >> buildPackages [
-	(project importPackageNamed: #'PharoLauncher-Download')
+	(project newNotLoadedPackage: #'PharoLauncher-Download')
 		description: 'Package dealing with image / VM detection and download.';
 		addDependencyOn: #'OSProcess::Core with Output';
 		addDependencyOn: #'ProcessWrapper::Core'.
-	(project importPackageNamed: #'PharoLauncher-Core')
+	(project newNotLoadedPackage: #'PharoLauncher-Core')
 		description: 'Core package with the model, commands and settings.';
 		addDependencyOn: #'PharoLauncher-Download';
 		addDependencyOn: #'XMLParser::Core';
 		addDependencyOn: #'Ston';
 		addDependencyOn: #'JSON'.
-	(project importPackageNamed: #'PharoLauncher-Spec')
+	(project newNotLoadedPackage: #'PharoLauncher-Spec')
 		description: 'PharoLauncher UI.';
 		addDependencyOn: #'PharoLauncher-Core'.
-	(project importPackageNamed: #'PharoLauncher-Tests-Download')
+	(project newNotLoadedPackage: #'PharoLauncher-Tests-Download')
 		description: 'Tests of the PharoLauncher-Download package.';
 		addDependencyOn: #'PharoLauncher-Download'.
-	(project importPackageNamed: #'PharoLauncher-Tests-Core')
+	(project newNotLoadedPackage: #'PharoLauncher-Tests-Core')
 		description: 'Tests of the PharoLauncher-Core package..';
 		addDependencyOn: #'PharoLauncher-Core'.
 ]
@@ -89,11 +89,13 @@ PharoLauncherProject >> buildProject [
     lets you manage your Pharo images (launch, rename, copy and delete);
     lets you download image templates (i.e., zip archives) from many different sources (e.g., Jenkins, files.pharo.org, and your local cache);
     lets you create new images from any template,
-    automatically find and download the appropriate VM to launch your images.
-';
+    automatically find and download the appropriate VM to launch your images.';
 		repository: self buildRepository;
 		registry: registry;
-		yourself
+		yourself.
+		
+	registry register: project.
+	^ project
 ]
 
 { #category : #building }

--- a/repository/CargoPackageManager/PBLoadableUnit.class.st
+++ b/repository/CargoPackageManager/PBLoadableUnit.class.st
@@ -114,6 +114,13 @@ PBLoadableUnit >> fitsPlatformRequirements [
 ]
 
 { #category : #initialization }
+PBLoadableUnit >> initialize [
+	super initialize.
+ 	dependencies := OrderedCollection new.
+	description := ''
+]
+
+{ #category : #initialization }
 PBLoadableUnit >> initializeFromPackageVersion: aCGOPackageVersion [
 	self subclassResponsibility
 ]

--- a/repository/CargoPackageManager/PBPackage.class.st
+++ b/repository/CargoPackageManager/PBPackage.class.st
@@ -26,10 +26,9 @@ PBPackage >> = anotherPackage [
 	^ self project = anotherPackage project
 ]
 
-{ #category : #updating }
-PBPackage >> addDependencyOn: aPackageName [ 
-	dependencies	add:
-		(CGOPackageDependency on: aPackageName)
+{ #category : #adding }
+PBPackage >> addDependencyOn: aPackageName [
+	self addDependency: (CGOPackageDependency on: aPackageName)
 ]
 
 { #category : #'accessing - dependencies' }
@@ -88,10 +87,9 @@ PBPackage >> initializeFromPackageVersion: aCGOPackageVersion [
 
 { #category : #initialization }
 PBPackage >> initializeWithPackageName: aPackageName andProject: aCargoProject [
-	
+	self initialize.
 	name := aPackageName.
 	project := aCargoProject.
-	dependencies := OrderedCollection new.
 	provisions := OrderedCollection new: 0.
 	platformRequirements := OrderedCollection new: 0.	
 ]

--- a/repository/CargoPackageManager/PBProject.class.st
+++ b/repository/CargoPackageManager/PBProject.class.st
@@ -91,7 +91,7 @@ PBProject >> addDependency: aDependency [
 	dependencies add: aDependency.
 	aDependency project: self.
 	
-	CGODependenciesChanged announceOnProject: self. 
+	self announceChangeInDependencies
 ]
 
 { #category : #updating }
@@ -102,6 +102,11 @@ PBProject >> addExternalCargoProject: aCGOProjectDependencyDeclaration [
 { #category : #dependencies }
 PBProject >> allDependencies [
 	^ dependencies , (packages flatCollect: #allDependencies).
+]
+
+{ #category : #dependencies }
+PBProject >> announceChangeInDependencies [
+	CGODependenciesChanged announceOnProject: self
 ]
 
 { #category : #converting }
@@ -264,11 +269,11 @@ PBProject >> initializeWithProjectName: aProjectName [
 	
 	self initialize.
 	name := aProjectName.
-	packages := Set new.
+	packages := OrderedCollection new.
 	assemblies := Set new.
 	virtualPackages := Set new.
 	externalProjects := Set new.
-	dependencies := OrderedCollection new
+
 ]
 
 { #category : #accessing }
@@ -457,10 +462,8 @@ PBProject >> removeAssembly: aPBAssembly [
 
 { #category : #dependencies }
 PBProject >> removeDependency: aDependency [
-
 	dependencies remove: aDependency.
-	
-	CGODependenciesChanged announceOnProject: self. 
+	self announceChangeInDependencies
 ]
 
 { #category : #packages }

--- a/repository/CargoPackageManager/PBProjectElement.class.st
+++ b/repository/CargoPackageManager/PBProjectElement.class.st
@@ -7,6 +7,14 @@ Class {
 	#category : #'CargoPackageManager-Model'
 }
 
+{ #category : #adding }
+PBProjectElement >> addDependency: aDependency [
+
+	dependencies add: aDependency.
+	aDependency project: self project.
+	self project announceChangeInDependencies.
+]
+
 { #category : #accessing }
 PBProjectElement >> fullyQualifiedName [
 


### PR DESCRIPTION
Making the Pharo Launcher example to correctly generates the objects.
Also improving the semantic versions to allow invalid versions (the one used in metacello).
Also the constraints that are equal we handle with or without the equal sign.

Fix #141
Fix #143