### PR TITLE
issue/150

### DIFF
--- a/repository/CargoPackageManager-IntegrationTests/CGOMetacelloConfigurationDependencyStatusWithSymbolicTest.class.st
+++ b/repository/CargoPackageManager-IntegrationTests/CGOMetacelloConfigurationDependencyStatusWithSymbolicTest.class.st
@@ -1,0 +1,34 @@
+Class {
+	#name : #CGOMetacelloConfigurationDependencyStatusWithSymbolicTest,
+	#superclass : #CGODependencyStatusTest,
+	#category : #'CargoPackageManager-IntegrationTests'
+}
+
+{ #category : #utils }
+CGOMetacelloConfigurationDependencyStatusWithSymbolicTest >> createProjectDependency [
+	^ PBMetacelloConfigurationProjectDependency  
+		name: 'JSON'
+		repositoryUrl: 'http://smalltalkhub.com/mc/PharoExtras/JSON/main/'
+		version: #stable
+]
+
+{ #category : #utils }
+CGOMetacelloConfigurationDependencyStatusWithSymbolicTest >> installProject [
+
+	Metacello new
+		configuration: 'JSON';
+		repository: 'http://smalltalkhub.com/mc/PharoExtras/JSON/main/';
+		version: '1.2';
+		load.
+
+]
+
+{ #category : #running }
+CGOMetacelloConfigurationDependencyStatusWithSymbolicTest >> tearDown [
+
+	(#JSON asPackageIfAbsent: [ nil ]) ifNotNil: #removeFromSystem.	
+	MetacelloProjectRegistration registry configurationRegistry removeKey: 'ConfigurationOfJSON' ifAbsent: [].
+	
+	super tearDown.
+	
+]

--- a/repository/CargoPackageManager-Minimal/PBMetacelloConfigurationProjectDependency.class.st
+++ b/repository/CargoPackageManager-Minimal/PBMetacelloConfigurationProjectDependency.class.st
@@ -38,7 +38,18 @@ PBMetacelloConfigurationProjectDependency >> isInstalledInMetacello [
 	
 	| conf |
 	conf := MetacelloProjectRegistration registry configurationRegistry at: (#ConfigurationOf , name) ifAbsent: [ ^ false ].	
-	^ conf version = version and: [ conf loadedInImage and: [ conf configurationProjectSpec loads isEmpty ]]
+	
+	^ version isSymbol ifTrue: [  
+		self isInstalledSymbolicVersion: conf.
+	] ifFalse: [  
+		conf version = version and: [ conf loadedInImage and: [ conf configurationProjectSpec loads isEmpty ]]
+	]
+	
+]
+
+{ #category : #testing }
+PBMetacelloConfigurationProjectDependency >> isInstalledSymbolicVersion: aMetacelloProjectRegistration [
+	^ (aMetacelloProjectRegistration configurationProjectSpec projectClass project version: version) versionString = aMetacelloProjectRegistration version
 ]
 
 { #category : #testing }


### PR DESCRIPTION
The Metacello Configuration dependencies should check the symbolic links to resolved versions to check if they are installed.
Fix #150